### PR TITLE
Create a GitHub Action related to #15

### DIFF
--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+line_count=$(wc -l < compiled_block_list.txt)
+line_count=$(echo $line_count | sed ':a;s/\B[0-9]\{3\}\>/,&/;ta')
+
+badge_ct="[![Statistics](https://img.shields.io/badge/sites-$line_count-brightgreen)](https://github.com/qurbat/blocked-hosts)"
+
+sed -i '2d' README.md
+sed -i "2i $badge_ct" README.md

--- a/.github/workflows/stats-badge.yml
+++ b/.github/workflows/stats-badge.yml
@@ -1,0 +1,24 @@
+name: Generate shields.io sites badge
+
+on:
+    push:
+        branches: main
+    pull_request:
+        branches: main
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+            
+            - name: Generate badge link
+              run: sh .github/workflows/generate.sh
+              
+            - name: Commit changes
+              uses: stefanzweifel/git-auto-commit-action@v5
+              with:
+                commit_message: Update the shields.io site count badge


### PR DESCRIPTION
Created a GitHub Action which generates a new shields.io badge for the number of sites logged in the compiled_block_list.txt.
I didn't have to generate a badge for 'GitHub last commit' since shields.io does it on their end.